### PR TITLE
Make extension run on local OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"onStartupFinished",
 		"onCommand:wallpaper-setting.guidance"
 	],
+	"extensionKind": ["ui", "workspace"]
 	"main": "./dist/extension.js",
 	"contributes": {
 		"commands": [


### PR DESCRIPTION
It's possible to run this extension in the local OS context and allow for WSL, DevContainers and Docker Containers to use the same wallpaper experience without extra steps (like syncing) by just setting the `extensionKind` to `[ui]`.

Given that users may still want to set different wallpapers or settings for different workspaces within, for example, DevContainers, I've set it to `[ui, workspace]` so that VSCode will allow the extension to run inside the Container's context if the end-user chooses to do so by just clicking on the "Install in DevContainer" button of the extensions navigator.

More info on this can be found in the VSCode docs:
https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location